### PR TITLE
Scan 1104 make jenkins plugin dsl compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+version 1.3.0
+-------------
+* New: The jenkins plugin is now DSL compatible
+
 version 1.2.0
 -------------
 * New: The jenkins plugin can now be configured to hit a specified proxy

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>com.datatheorem.mobileappsecurity.jenkins.plugin</groupId>
     <artifactId>datatheorem-mobile-app-security</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.0</version>
     <packaging>hpi</packaging>
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>com.datatheorem.mobileappsecurity.jenkins.plugin</groupId>
     <artifactId>datatheorem-mobile-app-security</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <packaging>hpi</packaging>
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>2.73.3</jenkins.version>
+        <jenkins.version>2.121.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <name>Data Theorem: CI/CD Plugin</name>

--- a/src/main/java/com/datatheorem/mobileappsecurity/jenkins/plugin/SendBuildAction.java
+++ b/src/main/java/com/datatheorem/mobileappsecurity/jenkins/plugin/SendBuildAction.java
@@ -67,7 +67,7 @@ class SendBuildAction {
     private final PrintStream logger; // Jenkins logger
     private final FilePath workspace;
     private String uploadUrl;
-    private String version = "1.2.0";
+    private String version = "1.3.0";
     private final String proxyHostname;
     private final int proxyPort;
     private final String proxyUsername;

--- a/src/main/java/com/datatheorem/mobileappsecurity/jenkins/plugin/SendBuildToDataTheoremPublisher.java
+++ b/src/main/java/com/datatheorem/mobileappsecurity/jenkins/plugin/SendBuildToDataTheoremPublisher.java
@@ -10,12 +10,10 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
 import jenkins.tasks.SimpleBuildStep;
-import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -262,17 +260,6 @@ public class SendBuildToDataTheoremPublisher extends Publisher implements Simple
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {
             return true;
         }
-
-        @Override
-        public SendBuildToDataTheoremPublisher newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            return req.bindJSON(SendBuildToDataTheoremPublisher.class,formData);
-        }
-        @Override
-        public boolean configure(StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
-            save();
-            return super.configure(req, formData);
-        }
-
     }
 
 

--- a/src/main/java/com/datatheorem/mobileappsecurity/jenkins/plugin/SendBuildToDataTheoremPublisher.java
+++ b/src/main/java/com/datatheorem/mobileappsecurity/jenkins/plugin/SendBuildToDataTheoremPublisher.java
@@ -4,21 +4,23 @@ import groovy.lang.Tuple2;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.AbstractProject;
-import hudson.model.Result;
-import hudson.model.Run;
-import hudson.model.TaskListener;
+import hudson.model.*;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
 import jenkins.tasks.SimpleBuildStep;
+import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.io.Serializable;
+
 /**
  * This class aims to provide a simple plugin to automatically upload builds to Data Theorem Upload API.
  * <p>
@@ -28,14 +30,16 @@ import java.io.IOException;
  * https://wiki.jenkins.io/display/JENKINS/Credentials+Plugin
  * </p>
  */
-public class SendBuildToDataTheoremPublisher extends Publisher implements SimpleBuildStep {
-    private final String buildToUpload;
+
+public class SendBuildToDataTheoremPublisher extends Publisher implements SimpleBuildStep, Serializable {
+    private  String buildToUpload;
     private final boolean dontUpload;
     private final String proxyHostname;
     private final int proxyPort;
     private final String proxyUsername;
     private final String proxyPassword;
     private final boolean proxyUnsecuredConnection;
+    private String dataTheoremUploadApiKey = null;
 
     @DataBoundConstructor
     public SendBuildToDataTheoremPublisher(
@@ -45,9 +49,10 @@ public class SendBuildToDataTheoremPublisher extends Publisher implements Simple
             int proxyPort,
             String proxyUsername,
             String proxyPassword,
-            boolean proxyUnsecuredConnection) {
+            boolean proxyUnsecuredConnection
+        ) {
         /*
-        Bind the parameter value of the job configuration page
+        * Bind the parameter value of the job configuration page
         */
         this.buildToUpload = buildToUpload;
         this.dontUpload = dontUpload;
@@ -56,6 +61,41 @@ public class SendBuildToDataTheoremPublisher extends Publisher implements Simple
         this.proxyUsername = proxyUsername;
         this.proxyPassword = proxyPassword;
         this.proxyUnsecuredConnection = proxyUnsecuredConnection;
+    }
+
+    public String getDataTheoremUploadApiKey() {
+        return dataTheoremUploadApiKey;
+    }
+
+    @DataBoundSetter
+    public void setDataTheoremUploadApiKey(String dataTheoremUploadApiKey) {
+        /*
+        * dataTheoremUploadApiKey can be set in a jenkins pipeline by adding dataTheoremUploadApiKey parameter at the call of the plugin
+        */
+        this.dataTheoremUploadApiKey = dataTheoremUploadApiKey;
+    }
+
+    private String getSecretKey(Run<?,?> run, TaskListener listener) throws IOException, InterruptedException {
+    /*
+    * Environment variable is handled differently as a pipeline step or as a post-build action
+    * Documentation: https://jenkins.io/doc/developer/plugin-development/pipeline-integration/ section "Variable substitutions"
+    */
+        if (run instanceof AbstractBuild) {
+            //As a post-build action we have access to any defined environment variable value
+            listener.getLogger().println("Data Theorem Upload Build plugin is running as a post-build action");
+            return run.getEnvironment(listener).get("DATA_THEOREM_UPLOAD_API_KEY");
+        } else {
+            //As a pipeline step, the plugin should take any configuration values as literal strings
+            listener.getLogger().println(
+                    "Data Theorem Upload Build plugin is called from a jenkins pipeline script"
+            );
+            if (this.dataTheoremUploadApiKey == null)
+                listener.getLogger().println(
+                        "You should set dataTheoremUploadApiKey " +
+                        "with DATA_THEOREM_UPLOAD_API_KEY environment variable value "
+                );
+            return this.dataTheoremUploadApiKey;
+        }
     }
 
     @Override
@@ -96,16 +136,16 @@ public class SendBuildToDataTheoremPublisher extends Publisher implements Simple
                     listener.getLogger().println("No proxy configuration");
 
                     sendBuild = new SendBuildAction(
-                            run.getEnvironment(listener).get("DATA_THEOREM_UPLOAD_API_KEY"),
+                            getSecretKey(run, listener),
                             listener.getLogger(),
                             workspace
                     );
                 }
                 else {
-                        listener.getLogger().println("Proxy Configuration is : " + proxyHostname + ":" + proxyPort);
+                    listener.getLogger().println("Proxy Configuration is : " + proxyHostname + ":" + proxyPort);
 
-                        sendBuild = new SendBuildAction(
-                            run.getEnvironment(listener).get("DATA_THEOREM_UPLOAD_API_KEY"),
+                    sendBuild = new SendBuildAction(
+                            getSecretKey(run, listener),
                             listener.getLogger(),
                             workspace,
                             proxyHostname,
@@ -113,8 +153,8 @@ public class SendBuildToDataTheoremPublisher extends Publisher implements Simple
                             proxyUsername,
                             proxyPassword,
                             proxyUnsecuredConnection
-                        );
-                    }
+                    );
+                }
 
                 SendBuildMessage sendBuildResult = sendBuild.perform(buildPath, isBuildStoredInArtifactFolder);
                 if (!sendBuildResult.message.equals("")) {
@@ -181,14 +221,28 @@ public class SendBuildToDataTheoremPublisher extends Publisher implements Simple
 
         return proxyUnsecuredConnection;
     }
-    @Symbol("Data Theorem")
+
+
     @Extension
+    // Define the symbols needed to call the jenkins plugin in a DSL pipeline
+    @Symbol({
+            "sendBuildToDataTheorem",
+            "buildToUpload",
+            "dontUpload",
+            "proxyHostname",
+            "proxyPort",
+            "proxyUsername",
+            "proxyPassword",
+            "proxyUnsecuredConnection",
+            "dataTheoremUploadApiKey"
+    })
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+
         /*
          * Validate that the build name parameter in job configuration page is not left empty
          */
 
-        public FormValidation doCheckBuildToUpload(@QueryParameter("buildToUpload") String value) {
+        public FormValidation doCheckBuildToUpload(@QueryParameter(value = "buildToUpload") String value) {
             if (value.length() == 0)
                 return FormValidation.error("The build name is empty");
             if (!value.toLowerCase().endsWith(".apk") && !value.toLowerCase().endsWith(".ipa"))
@@ -208,6 +262,17 @@ public class SendBuildToDataTheoremPublisher extends Publisher implements Simple
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {
             return true;
         }
+
+        @Override
+        public SendBuildToDataTheoremPublisher newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            return req.bindJSON(SendBuildToDataTheoremPublisher.class,formData);
+        }
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
+            save();
+            return super.configure(req, formData);
+        }
+
     }
 
 


### PR DESCRIPTION
I had to update jenkins minimal version from 2.73 to 2.121.1 ( early 2018 version )

Jenkins official documentation teaches us that as a pipeline step we can't read any declared environment variable so they will have to send it as a parameter.
https://jenkins.io/doc/developer/plugin-development/pipeline-integration/

I used their official way for making the plugin both compatible DSL pipeline and post-build action compatible . 

Below a complete example of a DSL step using our build that i'll add to the documentation:

```
stage('Upload Build To Data Theorem') {
             
   steps
  {

       withCredentials([string(credentialsId: 'dt_upload_key', variable: 'DATA_THEOREM_UPLOAD_API_KEY')]) 
       {
        sendBuildToDataTheorem buildToUpload: '{,**/}*android*.*', dontUpload: false, dataTheoremUploadApiKey: env.DATA_THEOREM_UPLOAD_API_KEY, proxyHostname: '',proxyUsername:'', proxyPassword: '', proxyPort: 0, proxyUnsecuredConnection: false
       }
   }
}

```
 