### PR TITLE
Modify proxy password

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>com.datatheorem.mobileappsecurity.jenkins.plugin</groupId>
     <artifactId>datatheorem-mobile-app-security</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.4.0</version>
     <packaging>hpi</packaging>
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->

--- a/src/main/java/com/datatheorem/mobileappsecurity/jenkins/plugin/SendBuildAction.java
+++ b/src/main/java/com/datatheorem/mobileappsecurity/jenkins/plugin/SendBuildAction.java
@@ -67,7 +67,7 @@ class SendBuildAction {
     private final PrintStream logger; // Jenkins logger
     private final FilePath workspace;
     private String uploadUrl;
-    private String version = "1.3.0";
+    private String version = "1.4.0";
     private final String proxyHostname;
     private final int proxyPort;
     private final String proxyUsername;

--- a/src/main/java/com/datatheorem/mobileappsecurity/jenkins/plugin/SendBuildToDataTheoremPublisher.java
+++ b/src/main/java/com/datatheorem/mobileappsecurity/jenkins/plugin/SendBuildToDataTheoremPublisher.java
@@ -9,6 +9,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -35,7 +36,7 @@ public class SendBuildToDataTheoremPublisher extends Publisher implements Simple
     private final String proxyHostname;
     private final int proxyPort;
     private final String proxyUsername;
-    private final String proxyPassword;
+    private Secret proxyPassword = null;
     private final boolean proxyUnsecuredConnection;
     private String dataTheoremUploadApiKey = null;
 
@@ -57,7 +58,7 @@ public class SendBuildToDataTheoremPublisher extends Publisher implements Simple
         this.proxyHostname = proxyHostname;
         this.proxyPort = proxyPort;
         this.proxyUsername = proxyUsername;
-        this.proxyPassword = proxyPassword;
+        this.proxyPassword = Secret.fromString(proxyPassword);
         this.proxyUnsecuredConnection = proxyUnsecuredConnection;
     }
 
@@ -103,6 +104,7 @@ public class SendBuildToDataTheoremPublisher extends Publisher implements Simple
             @Nonnull Launcher launcher,
             TaskListener listener
     ) throws InterruptedException, IOException {
+
         SendBuildAction sendBuild;
         listener.getLogger().println("Data Theorem upload build plugin starting...");
         Result result = run.getResult();
@@ -149,7 +151,7 @@ public class SendBuildToDataTheoremPublisher extends Publisher implements Simple
                             proxyHostname,
                             proxyPort,
                             proxyUsername,
-                            proxyPassword,
+                            proxyPassword.getPlainText(),
                             proxyUnsecuredConnection
                     );
                 }
@@ -166,6 +168,7 @@ public class SendBuildToDataTheoremPublisher extends Publisher implements Simple
             listener.getLogger().println("Unable to find any build with name : " + this.buildToUpload);
             run.setResult(Result.UNSTABLE);
         }
+       run.setResult(Result.SUCCESS);
     }
 
     @Override
@@ -208,10 +211,10 @@ public class SendBuildToDataTheoremPublisher extends Publisher implements Simple
         return proxyUsername;
     }
 
-    public String getProxyPassword() {
-        // Required to get the last value when we update a job config
+    public Secret getProxyPassword() {
+        // Returns the encrypted value of the field
 
-        return proxyPassword;
+        return this.proxyPassword;
     }
 
     public boolean getProxyUnsecuredConnection() {

--- a/src/test/java/com/datatheorem/mobileappsecurity/jenkins/plugin/SendBuildToDataTheoremPublisherTest.java
+++ b/src/test/java/com/datatheorem/mobileappsecurity/jenkins/plugin/SendBuildToDataTheoremPublisherTest.java
@@ -42,7 +42,7 @@ public class SendBuildToDataTheoremPublisherTest {
         job = jenkins.configRoundtrip(job);
 
         SendBuildToDataTheoremPublisher lhs = new SendBuildToDataTheoremPublisher(
-                buildName, dontUpload, proxyHostname, proxyPort, proxyUsername, "", proxyUnsecuredConnection);
+                buildName, dontUpload, proxyHostname, proxyPort, proxyUsername, proxyPassword, proxyUnsecuredConnection);
         jenkins.assertEqualDataBoundBeans(lhs, job.getPublishersList().get(0));
     }
 


### PR DESCRIPTION
I modified the secret field so that it's working for both pipeline and normal project

This will not require any change for customer and this is fully compatible without any intervention ( i have tested an upgrade and the previous jobs are still working even if a proxy password was set, and in that case the proxypassword get encrypted) 

For DSL Pipelines normally it's to the user plugin to hide the password using credential plugin. We should recommend the user to do so on the wiki  but we don't need to change anything for a pipeline script. 
I will also need to open a PR on the private jenkinsci repo and when they validate the change, i should be able to release the change directly